### PR TITLE
Delete the readonly attribute of SimplePrinter classe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Print your PHPUnit result in JSON, so other tool can pipe it",
     "license": "MIT",
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "phpunit/phpunit": "^10.5|^11.0"
     },
     "require-dev": {

--- a/src/Printer/SimplePrinter.php
+++ b/src/Printer/SimplePrinter.php
@@ -6,7 +6,7 @@ namespace TomasVotruba\PHPUnitJsonResultPrinter\Printer;
 
 use PHPUnit\TextUI\Output\Printer;
 
-final readonly class SimplePrinter
+final class SimplePrinter
 {
     public function __construct(
         private Printer $phpunitPrinter


### PR DESCRIPTION
Readonly classes are not allowed in php 8.1

https://php.watch/versions/8.2/readonly-classes